### PR TITLE
Move from deprecated `set-output` command to `GITHUB_OUTPUT` environment variable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           changed=$(ct list-changed --config .github/workflows/config/chart-lint.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)


### PR DESCRIPTION
To mitigate the following warning:
```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
Indeed, according to https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/, workflows still using this keyword will start failing on 1st June, 2023, and this day will come soon enough.

Needs to be tested using the branch name as a tag in workflows that use it.